### PR TITLE
Feat/reader

### DIFF
--- a/src/DummyMycBuyer.sol
+++ b/src/DummyMycBuyer.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {ERC20} from "solmate/tokens/ERC20.sol";
-import {IMycBuyer} from "interfaces/IMycBuyer.sol";
+import {IMycBuyer} from "./interfaces/IMycBuyer.sol";
 import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
 
 contract DummyMycBuyer is IMycBuyer {

--- a/src/LentMyc.sol
+++ b/src/LentMyc.sol
@@ -7,7 +7,7 @@ import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
-import {IMycBuyer} from "interfaces/IMycBuyer.sol";
+import {IMycBuyer} from "./interfaces/IMycBuyer.sol";
 
 interface ISelfTransfer {
     function selfTransfer(address to, uint256 amount) external returns (bool);

--- a/src/interfaces/ILentMyc.sol
+++ b/src/interfaces/ILentMyc.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+interface ILentMyc {
+    function cycle() external view returns (uint256);
+    function dust() external view returns (uint256);
+    function cycleCumulativeEthRewards(uint256) external view returns (uint256);
+    function cycleSharesAndAssets(uint256) external view returns (uint256 _totalSupply, uint256 _totalAssets);
+    function totalAssets() external view returns (uint256);
+    function totalSupply() external view returns (uint256);
+    function pendingDeposits() external view returns (uint256);
+    function pendingRedeems() external view returns (uint256);
+
+    function convertToShares(uint256 _assets, uint256 _totalAssets, uint256 _totalSupply)
+        external
+        view
+        returns (uint256);
+}

--- a/src/peripherals/LentMycReader.sol
+++ b/src/peripherals/LentMycReader.sol
@@ -11,11 +11,6 @@ import {ILentMyc} from "../interfaces/ILentMyc.sol";
 contract LentMycReader {
     using FixedPointMathLib for uint256;
 
-    struct CycleInfo {
-        uint256 totalSupply;
-        uint256 totalAssets;
-    }
-
     /// @notice External function to access internal _getCurrentCycleInfo
     function getCurrentCycleInfo(address lentMyc_, uint256 ethRewards) external view returns (uint256[] memory) {
         return _getCurrentCycleInfo(lentMyc_, ethRewards);

--- a/src/peripherals/LentMycReader.sol
+++ b/src/peripherals/LentMycReader.sol
@@ -71,7 +71,6 @@ contract LentMycReader {
 
         (uint256 cycleSupply, uint256 cycleMyc) =  lentMyc.cycleSharesAndAssets(cycle);
 
-
         if (fetchingCurrentCycle) {
             uint256 lastCyclesEthRewards = cyclesEthRewardsPerShare.mulWadDown(cycleSupply);
             return _getCurrentCycleInfo(lentMyc_, lastCyclesEthRewards);

--- a/src/peripherals/LentMycReader.sol
+++ b/src/peripherals/LentMycReader.sol
@@ -6,7 +6,7 @@ import {ILentMyc} from "../interfaces/ILentMyc.sol";
 
 /**
  * @title MYC Lending contract reader
- * @author Dospore
+ * @author Dospore.
  */
 contract LentMycReader {
     using FixedPointMathLib for uint256;
@@ -18,17 +18,17 @@ contract LentMycReader {
     }
 
     /**
-     * @notice External function to access internal _getCurrentCycleInfo
+     * @notice External function to access internal _getCurrentCycleInfo.
      */
     function getCurrentCycleInfo(address lentMyc_, uint256 ethRewards) external view returns (CycleInfo memory) {
         return _getCurrentCycleInfo(lentMyc_, ethRewards);
     }
 
     /**
-     * @notice Get the current cycles reward reward and info given an eth reward amount
-     * @param lentMyc_ address of lentMyc
-     * @param ethRewards amount of eth that will be rewarded to current cycle stakers
-     * @return Current cycles reward info based on the given eth rewards amount
+     * @notice Get the current cycles reward reward and info given an eth reward amount.
+     * @param lentMyc_ address of lentMyc.
+     * @param ethRewards amount of eth that will be rewarded to current cycle stakers.
+     * @return Current cycles reward info based on the given eth rewards amount.
      */
     function _getCurrentCycleInfo(address lentMyc_, uint256 ethRewards) internal view returns (CycleInfo memory) {
         ILentMyc lentMyc = ILentMyc(lentMyc_);
@@ -51,10 +51,10 @@ contract LentMycReader {
     }
 
     /**
-     * @notice Get an arbitrary cycle's info
-     * @param lentMyc_ address of lentMyc
-     * @param cycle number to retrieve info on
-     * @return Given cycles reward info or the currentCycles info based on the previous cycle
+     * @notice Get an arbitrary cycle's info.
+     * @param lentMyc_ address of lentMyc.
+     * @param cycle number to retrieve info on.
+     * @return Given cycles reward info or the currentCycles info based on the previous cycle.
      */
     function getCycleInfo(address lentMyc_, uint256 cycle) external view returns (CycleInfo memory) {
         ILentMyc lentMyc = ILentMyc(lentMyc_);

--- a/src/peripherals/LentMycReader.sol
+++ b/src/peripherals/LentMycReader.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
+import {ILentMyc} from "../interfaces/ILentMyc.sol";
+
+/**
+ * @title MYC Lending contract reader
+ * @author Dospore
+ */
+contract LentMycReader {
+    using FixedPointMathLib for uint256;
+
+    struct CycleInfo {
+        uint256 totalSupply;
+        uint256 totalAssets;
+    }
+
+    /// get the current cycles apr
+    function getCurrentCycleInfo(address lentMyc_, uint256 ethRewards) external view returns (uint256[] memory) {
+        return _getCurrentCycleInfo(lentMyc_, ethRewards);
+    }
+
+    function _getCurrentCycleInfo(address lentMyc_, uint256 ethRewards) internal view returns (uint256[] memory) {
+        ILentMyc lentMyc = ILentMyc(lentMyc_);
+
+        uint256 dust = lentMyc.dust();
+        uint256 pendingRedeems = lentMyc.pendingRedeems();
+
+        uint256 currentCycleSupply = lentMyc.totalSupply() + pendingRedeems;
+        uint256 currentCycleMyc = lentMyc.totalAssets();
+
+        uint256 currentCyclesEthRewardsPerShare = (ethRewards + dust).divWadDown(currentCycleSupply);
+
+        uint256[] memory info;
+        info[0] = currentCyclesEthRewardsPerShare;
+        info[1] = currentCycleSupply;
+        info[2] = currentCycleMyc;
+
+        return info;
+    }
+
+
+
+    /// Fetches
+    function getCycleInfo(address lentMyc_, uint256 cycle) external view returns (uint256[] memory) {
+        ILentMyc lentMyc = ILentMyc(lentMyc_);
+        uint256 cycle_ = lentMyc.cycle();
+        bool fetchingCurrentCycle = false;
+        if (cycle >= cycle_) {
+            // set to cycle_ - 1
+            cycle = cycle_ - 1;
+            fetchingCurrentCycle = true;
+        }
+
+        uint256 previousCumaltiveEthRewardsPerShare = lentMyc.cycleCumulativeEthRewards(cycle - 1);
+        uint256 cyclesCumaltiveEthRewardsPerShare = lentMyc.cycleCumulativeEthRewards(cycle);
+        uint256 cyclesEthRewardsPerShare = previousCumaltiveEthRewardsPerShare - cyclesCumaltiveEthRewardsPerShare;
+
+        (uint256 cycleSupply, uint256 cycleMyc) =  lentMyc.cycleSharesAndAssets(cycle);
+
+
+        if (fetchingCurrentCycle) {
+            uint256 lastCyclesEthRewards = cyclesEthRewardsPerShare.mulWadDown(cycleSupply);
+            return _getCurrentCycleInfo(lentMyc_, lastCyclesEthRewards);
+        }
+
+        uint256[] memory info;
+        info[0] = cyclesEthRewardsPerShare;
+        info[1] = cycleSupply;
+        info[2] = cycleMyc;
+
+        return info;
+    }
+}

--- a/src/peripherals/LentMycReader.sol
+++ b/src/peripherals/LentMycReader.sol
@@ -16,11 +16,16 @@ contract LentMycReader {
         uint256 totalAssets;
     }
 
-    /// get the current cycles apr
+    /// @notice External function to access internal _getCurrentCycleInfo
     function getCurrentCycleInfo(address lentMyc_, uint256 ethRewards) external view returns (uint256[] memory) {
         return _getCurrentCycleInfo(lentMyc_, ethRewards);
     }
 
+    /// @notice Get the current cycles reward reward and info given an eth reward amount
+    /// @dev Dospore
+    /// @param lentMyc_ address of lentMyc
+    /// @param ethRewards amount of eth that will be rewarded to current cycle stakers
+    /// @return Current cycles reward info based on the given eth rewards amount
     function _getCurrentCycleInfo(address lentMyc_, uint256 ethRewards) internal view returns (uint256[] memory) {
         ILentMyc lentMyc = ILentMyc(lentMyc_);
 
@@ -41,14 +46,16 @@ contract LentMycReader {
     }
 
 
-
-    /// Fetches
+    /// @notice Get an arbitrary cycles info
+    /// @dev Dospore
+    /// @param lentMyc_ address of lentMyc
+    /// @param cycle number to retrieve info on
+    /// @return Given cycles reward info or the currentCycles info based on the previous cycle
     function getCycleInfo(address lentMyc_, uint256 cycle) external view returns (uint256[] memory) {
         ILentMyc lentMyc = ILentMyc(lentMyc_);
         uint256 cycle_ = lentMyc.cycle();
         bool fetchingCurrentCycle = false;
         if (cycle >= cycle_) {
-            // set to cycle_ - 1
             cycle = cycle_ - 1;
             fetchingCurrentCycle = true;
         }


### PR DESCRIPTION
Add reader with two helper functions. This is basically just to make calculating the current apr easier. You can either use getCurrentCycleInfo with an expected rewards amount or getCycleInfo to get a previous cycles rewards amount. This info can be multiplied by the current eth price and mycPrice to calculate apr


- getCurrentCycleInfo gets the rewardsPerShare, supply and assets for the current cycle. The rewardsPerShare is based on a supplied ethRewardAmount. This can be used in conjunction with getCycleInfo which will use the previous cycles eth rewards to estimate a current cycle reward. Or you can pass it any arbitrary reward amount
- getCycleInfo will retrieve the info related to a given cycle. If you pass a cycle higher than the current cycle it will just get current cycle info